### PR TITLE
Fix three code bugs

### DIFF
--- a/custom_components/lumentree/services/cache.py
+++ b/custom_components/lumentree/services/cache.py
@@ -67,6 +67,25 @@ def cache_path(device_id: str, year: int) -> str:
     return os.path.join(dev_dir, f"{year}.json")
 
 
+def list_cached_years(device_id: str) -> list[int]:
+    """Return sorted list of years that have cached statistics files."""
+    dev_dir = os.path.join(CACHE_BASE_DIR, device_id)
+    if not os.path.isdir(dev_dir):
+        return []
+    years: list[int] = []
+    try:
+        for entry in os.listdir(dev_dir):
+            if not entry.endswith(".json"):
+                continue
+            try:
+                years.append(int(entry[:-5]))
+            except ValueError:
+                continue
+    except Exception:
+        return []
+    return sorted(years)
+
+
 def load_year(device_id: str, year: int) -> Dict[str, Any]:
     path = cache_path(device_id, year)
     if not os.path.exists(path):

--- a/custom_components/lumentree/services/smart_backfill.py
+++ b/custom_components/lumentree/services/smart_backfill.py
@@ -102,9 +102,9 @@ async def backfill_month_from_api(
         import calendar
         days_in_month = calendar.monthrange(year, month)[1]
         
-        # Process each day
+        # Process each day (always iterate full calendar month; individual series may be shorter)
         daily = cache.setdefault("daily", {})
-        for day in range(1, min(len(pv_daily), days_in_month) + 1):
+        for day in range(1, days_in_month + 1):
             date_str = f"{year}-{month:02d}-{day:02d}"
             
             # Check if day already exists and has data


### PR DESCRIPTION
Fixes three bugs: incomplete monthly backfill, missing current year's saved/total load in lifetime totals, and limited 10-year scan for lifetime data.

The backfill loop now iterates the full calendar month to ensure all days are processed, even if a specific data series (like PV) is shorter. `_get_current_year_data()` now includes `total_load`, `saved_kwh`, and `savings_vnd` to correctly aggregate current year's contributions to lifetime totals. The lifetime coordinator now dynamically lists and processes all available cached years instead of a fixed 10-year window, ensuring all historical data is included.

---
<a href="https://cursor.com/background-agent?bcId=bc-88951213-3cfa-460a-b14e-2b74912290af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88951213-3cfa-460a-b14e-2b74912290af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aggregate totals now scan all cached years and include current-year total/savings metrics; backfill processes every day of each month.
> 
> - **Totals aggregation (`custom_components/lumentree/coordinators/total_coordinator.py`)**:
>   - Use `cache.list_cached_years()` plus current year to process actual cached years (not fixed 10-year window); track `earliest_year`/`latest_year` accurately.
>   - Include current year `total_load`, `saved_kwh`, and `savings_vnd` from yearly coordinator in lifetime totals; add fallback when `total_load` is missing.
> - **Cache (`custom_components/lumentree/services/cache.py`)**:
>   - Add `list_cached_years(device_id)` to enumerate available cached year files.
> - **Backfill (`custom_components/lumentree/services/smart_backfill.py`)**:
>   - Backfill now iterates all `days_in_month`, ensuring full-month processing even if some daily series are shorter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36fe785db12a1a134b4652684bf34f36e3904e7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->